### PR TITLE
feat(#44): allow both userinfo variants, prepare introspection

### DIFF
--- a/internal/repository/config/config.go
+++ b/internal/repository/config/config.go
@@ -100,6 +100,10 @@ func OidcUserInfoURL() string {
 	return configuration().Security.Oidc.UserInfoURL
 }
 
+func OidcTokenIntrospectionURL() string {
+	return configuration().Security.Oidc.TokenIntrospectionURL
+}
+
 func OidcUserInfoCacheRetentionTime() time.Duration {
 	return time.Duration(configuration().Security.Oidc.UserInfoCacheSeconds) * time.Second
 }

--- a/internal/repository/config/structure.go
+++ b/internal/repository/config/structure.go
@@ -41,6 +41,7 @@ type (
 		RelevantGroups        map[string][]string `yaml:"relevant_groups"`          // key is IDP group id, value is list of allowed subjects (all allowed if value is empty list)
 		TokenPublicKeysPEM    []string            `yaml:"token_public_keys_PEM"`    // a list of public RSA keys in PEM format, see https://github.com/Jumpy-Squirrel/jwks2pem for obtaining PEM from openid keyset endpoint
 		UserInfoURL           string              `yaml:"user_info_url"`            // validation of admin accesses uses this endpoint to verify the token is still current and access has not been recently revoked
+		TokenIntrospectionURL string              `yaml:"token_introspection_url"`  // validation of tokens uses this endpoint to obtain scopes and audiences
 		UserInfoCacheSeconds  int                 `yaml:"user_info_cache_seconds"`  // leave at 0 to disable caching
 		Audience              string              `yaml:"audience"`
 		Issuer                string              `yaml:"issuer"`

--- a/internal/repository/idp/interface.go
+++ b/internal/repository/idp/interface.go
@@ -29,10 +29,31 @@ type UserinfoData struct {
 	Subject       string   `json:"sub"` //
 }
 
-type UserinfoResponseDto struct {
-	Data UserinfoData `json:"data"`
+type TokenIntrospectionData struct {
+	Active    bool     `json:"active"`
+	Scope     string   `json:"scope"`
+	ClientId  string   `json:"client_id"`
+	Sub       string   `json:"sub"`
+	Exp       int64    `json:"exp"`
+	Iat       int64    `json:"iat"`
+	Nbf       int64    `json:"nbf"`
+	Aud       []string `json:"aud"`
+	Iss       string   `json:"iss"`
+	TokenType string   `json:"token_type"`
+	TokenUse  string   `json:"token_use"`
 
 	// in case of error, you get these fields instead
+	ErrorMessage string              `json:"message"`
+	Errors       map[string][]string `json:"errors"`
+}
+
+type UserinfoResponseDto struct {
+	UserinfoData
+
+	// TODO temporarily retain old version
+	Data UserinfoData `json:"data"`
+
+	// in case of error, you get these fields instead (old version)
 	ErrorCode        string `json:"error"`
 	ErrorDescription string `json:"error_description"`
 }
@@ -41,4 +62,6 @@ type IdentityProviderClient interface {
 	TokenWithAuthenticationCodeAndPKCE(ctx context.Context, applicationConfigName string, authorizationCode string, pkceVerifier string) (*TokenResponseDto, int, error)
 
 	UserInfo(ctx context.Context) (*UserinfoData, int, error)
+
+	TokenIntrospection(ctx context.Context) (*TokenIntrospectionData, int, error)
 }

--- a/test/acceptance/mock_idp_test.go
+++ b/test/acceptance/mock_idp_test.go
@@ -72,3 +72,9 @@ func (m *mockIDPClient) UserInfo(ctx context.Context) (*idp.UserinfoData, int, e
 	}
 	return &ret, http.StatusOK, nil
 }
+
+func (m *mockIDPClient) TokenIntrospection(ctx context.Context) (*idp.TokenIntrospectionData, int, error) {
+	ret := idp.TokenIntrospectionData{}
+	// TODO implement
+	return &ret, http.StatusOK, nil
+}

--- a/test/contract/consumer/pacts/regauthservice-identityprovider.json
+++ b/test/contract/consumer/pacts/regauthservice-identityprovider.json
@@ -49,6 +49,16 @@
           "Content-Type": "application/json"
         },
         "body": {
+          "aud": null,
+          "auth_time": 0,
+          "email": "",
+          "email_verified": false,
+          "name": "",
+          "groups": null,
+          "iss": "",
+          "iat": 0,
+          "rat": 0,
+          "sub": "",
           "data": {
             "aud": [
               "123897612987-12987-12389"
@@ -68,6 +78,74 @@
           },
           "error": "",
           "error_description": ""
+        }
+      }
+    },
+    {
+      "description": "a userinfo request (new version without data)",
+      "providerState": "a user is logged in",
+      "request": {
+        "method": "GET",
+        "path": "/userinfo",
+        "headers": {
+          "Authorization": "Bearer ZYX"
+        }
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "body": {
+          "aud": [
+            "123897612987-12987-12389"
+          ],
+          "auth_time": 0,
+          "email": "me@example.com",
+          "email_verified": true,
+          "name": "me",
+          "groups": [
+            "comedian",
+            "fursuiter"
+          ],
+          "iss": "",
+          "iat": 0,
+          "rat": 0,
+          "sub": "1234567"
+        }
+      }
+    },
+    {
+      "description": "a token introspection request",
+      "providerState": "a user is logged in",
+      "request": {
+        "method": "GET",
+        "path": "/token-introspection",
+        "headers": {
+          "Authorization": "Bearer ZYX"
+        }
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "body": {
+          "active": true,
+          "scope": "offline_access offline openid profile email groups groups.read groups.write groups.delete",
+          "client_id": "2c0a8861-8097-42a5-ba7e-34c00f7a640b",
+          "sub": "R1243MK1W5XWJ680",
+          "exp": 1678672221,
+          "iat": 1678668621,
+          "nbf": 1678668621,
+          "aud": [
+            "123897612987-12987-12389"
+          ],
+          "iss": "http://identity.eurofurence.localhost/",
+          "token_type": "Bearer",
+          "token_use": "access_token",
+          "message": "",
+          "errors": null
         }
       }
     }

--- a/test/resources/config-contracttests.yaml
+++ b/test/resources/config-contracttests.yaml
@@ -6,6 +6,7 @@ server:
 security:
   oidc:
     user_info_url: http://localhost:{{ .pactPort }}/userinfo
+    token_introspection_url: http://localhost:{{ .pactPort }}/token-introspection
   cors:
     disable: false
 identity_provider:


### PR DESCRIPTION
- partially implements #44 
