### PR TITLE
fix(#71): allow generic error url config

### DIFF
--- a/docs/config.example.yaml
+++ b/docs/config.example.yaml
@@ -2,6 +2,8 @@ service:
   name: 'Registration Auth Service'
   # external url of my own "dropoff" endpoint. This must match the OAuth2 redirect_url setting on each client
   dropoff_endpoint_url: https://my.own.domain.example.com/v1/dropoff
+  # error url if no application config could be determined, shown to the user as a clickable link
+  error_url: https://my.dashboard.example.com
 server:
   port: 4712
 security:

--- a/internal/repository/config/config.go
+++ b/internal/repository/config/config.go
@@ -55,6 +55,10 @@ func DropoffEndpointUrl() string {
 	return configuration().Service.DropoffEndpointUrl
 }
 
+func ErrorUrl() string {
+	return configuration().Service.ErrorUrl
+}
+
 func TokenRequestTimeout() time.Duration {
 	return configuration().IdentityProvider.TokenRequestTimeout
 }

--- a/internal/repository/config/structure.go
+++ b/internal/repository/config/structure.go
@@ -18,6 +18,7 @@ type (
 	ServiceConfig struct {
 		Name               string `yaml:"name"`
 		DropoffEndpointUrl string `yaml:"dropoff_endpoint_url"` // externally visible url to my "dropoff" endpoint
+		ErrorUrl           string `yaml:"error_url"`            // externally visible default error url
 	}
 
 	// ServerConfig contains all values for http configuration

--- a/internal/web/controller/dropoffctl/dropoffctl.go
+++ b/internal/web/controller/dropoffctl/dropoffctl.go
@@ -36,19 +36,19 @@ func dropOffHandler(w http.ResponseWriter, r *http.Request) {
 	query := r.URL.Query()
 	state := query.Get("state")
 	if state == "" {
-		dropOffErrorHandler(ctx, w, state, http.StatusBadRequest, "state parameter is missing", "invalid parameters", "")
+		dropOffErrorHandler(ctx, w, state, http.StatusBadRequest, "state parameter is missing", "invalid parameters", config.ErrorUrl())
 		return
 	}
 
 	authRequest, err := database.GetRepository().GetAuthRequestByState(ctx, state)
 	if err != nil {
-		dropOffErrorHandler(ctx, w, state, http.StatusNotFound, "couldn't load auth request: "+err.Error(), "auth request not found or timed out", "")
+		dropOffErrorHandler(ctx, w, state, http.StatusNotFound, "couldn't load auth request: "+err.Error(), "auth request not found or timed out", config.ErrorUrl())
 		return
 	}
 
 	applicationConfig, err := config.GetApplicationConfig(authRequest.Application)
 	if err != nil {
-		dropOffErrorHandler(ctx, w, state, http.StatusInternalServerError, "couldn't load application config: "+err.Error(), "internal error", "")
+		dropOffErrorHandler(ctx, w, state, http.StatusInternalServerError, "couldn't load application config: "+err.Error(), "internal error", config.ErrorUrl())
 		return
 	}
 
@@ -61,13 +61,13 @@ func dropOffHandler(w http.ResponseWriter, r *http.Request) {
 
 	authCode := query.Get("code")
 	if authCode == "" {
-		dropOffErrorHandler(ctx, w, state, http.StatusBadRequest, "authorization_code parameter is missing", "invalid parameters", "")
+		dropOffErrorHandler(ctx, w, state, http.StatusBadRequest, "authorization_code parameter is missing", "invalid parameters", config.ErrorUrl())
 		return
 	}
 
 	idToken, accessToken, httpstatus, err := fetchToken(ctx, authCode, *authRequest)
 	if err != nil {
-		dropOffErrorHandler(ctx, w, state, httpstatus, "couldn't fetch access codes: "+err.Error(), "failed to fetch token", "")
+		dropOffErrorHandler(ctx, w, state, httpstatus, "couldn't fetch access codes: "+err.Error(), "failed to fetch token", config.ErrorUrl())
 		return
 	}
 

--- a/test/resources/config-acceptancetests.yaml
+++ b/test/resources/config-acceptancetests.yaml
@@ -1,6 +1,7 @@
 service:
   name: 'Registration Auth Service Acceptance Test Configuration'
   dropoff_endpoint_url: http://localhost:8081/v1/dropoff
+  error_url: http://localhost:8081/
 server:
   port: 8081
 security:


### PR DESCRIPTION
- add optional configuration for a generic error link to be shown to the user if dropoff fails
- closes #71 